### PR TITLE
feat: home에 있던 token이 유효한지 확인하는 코드를, ApiProvider로 이동

### DIFF
--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -6,7 +6,8 @@
     "alert": { "ok": "확인" },
     "auth": {
       "loginRequired": "로그인이 필요합니다. 로그인 페이지로 이동합니다.",
-      "sessionExpired": "세션이 만료되었습니다. 다시 로그인 해주세요."
+      "sessionExpired": "세션이 만료되었습니다. 다시 로그인 해주세요.",
+      "serverError": "서버에 문제가 발생했습니다. 나중에 다시 시도해 주세요."
     }
   },
   "memo": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,5 @@
 import App from 'App';
-import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 
 const rootElement = document.getElementById('root');
-rootElement &&
-  ReactDOM.createRoot(rootElement).render(
-    <StrictMode>
-      <App />
-    </StrictMode>
-  );
+rootElement && ReactDOM.createRoot(rootElement).render(<App />);

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -9,7 +9,7 @@ import { ApiContext } from 'utils';
 const queryClient = new QueryClient();
 
 const Home = () => {
-  const { checkTokenFromCookieWithAlert } = useContext(ApiContext);
+  const { checkTokenFromCookie } = useContext(ApiContext);
   const navigate = useNavigate();
 
   const handleNavigation = (page: string) => {
@@ -17,7 +17,7 @@ const Home = () => {
   };
 
   useEffect(() => {
-    checkTokenFromCookieWithAlert();
+    checkTokenFromCookie();
   }, []);
 
   return (

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,53 +1,23 @@
-import { useContext, useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import Cookies from 'js-cookie';
 import { ResponsiveLayout } from './components';
 import { useNavigate } from 'react-router-dom';
 import { HomeRouter } from './router';
-import { jwtDecode } from 'jwt-decode';
-import { AlertContext } from 'utils/context';
-import { useTranslation } from 'react-i18next';
+import { useContext, useEffect } from 'react';
+import { ApiContext } from 'utils';
 
 const queryClient = new QueryClient();
 
 const Home = () => {
+  const { checkTokenFromCookieWithAlert } = useContext(ApiContext);
   const navigate = useNavigate();
-  const { t } = useTranslation();
-  const { alert } = useContext(AlertContext);
-
-  const onAlertClick = (message: string, page: string) => {
-    alert(message).then(() => {
-      handleNavigation(page);
-    });
-  };
 
   const handleNavigation = (page: string) => {
     navigate(`/${page}`);
   };
 
   useEffect(() => {
-    const accessToken = Cookies.get('access_token');
-
-    interface TokenPayload {
-      exp: number;
-      iat: number;
-    }
-
-    const isTokenValid = (token: string) => {
-      if (!token) return false;
-
-      const decoded = jwtDecode<TokenPayload>(token);
-      const currentTime = Date.now() / 1000;
-
-      return decoded.exp > currentTime;
-    };
-
-    if (!accessToken) {
-      onAlertClick(t('utils.auth.loginRequired'), 'login');
-    } else if (!isTokenValid(accessToken)) {
-      onAlertClick(t('utils.auth.sessionExpired'), 'login');
-    }
+    checkTokenFromCookieWithAlert();
   }, []);
 
   return (

--- a/src/utils/context/ApiContext.tsx
+++ b/src/utils/context/ApiContext.tsx
@@ -3,13 +3,13 @@ import { createContext } from 'react';
 type ApiContextType = {
   authApi: any;
   refreshableApi: any;
-  checkTokenFromCookieWithAlert: () => void;
+  checkTokenFromCookie: () => void;
 };
 
 const ApiContext = createContext<ApiContextType>({
   authApi: null,
   refreshableApi: null,
-  checkTokenFromCookieWithAlert: () => {},
+  checkTokenFromCookie: () => {},
 });
 
 export default ApiContext;

--- a/src/utils/context/ApiContext.tsx
+++ b/src/utils/context/ApiContext.tsx
@@ -3,11 +3,13 @@ import { createContext } from 'react';
 type ApiContextType = {
   authApi: any;
   refreshableApi: any;
+  checkTokenFromCookieWithAlert: () => void;
 };
 
 const ApiContext = createContext<ApiContextType>({
   authApi: null,
   refreshableApi: null,
+  checkTokenFromCookieWithAlert: () => {},
 });
 
 export default ApiContext;

--- a/src/utils/provider/ApiProvider.tsx
+++ b/src/utils/provider/ApiProvider.tsx
@@ -1,14 +1,14 @@
-import Cookies from 'js-cookie';
-import { useContext, ReactNode, useState } from 'react';
+import { useEffect, useContext, ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertContext, ApiContext } from 'utils/context';
-import { isTokenResponse, refresh } from 'api/authApi/token';
-import { authApi, refreshableApi } from 'api';
 import { useNavigate } from 'react-router-dom';
-import { AlertDialog } from 'utils/dialog';
+import { jwtDecode } from 'jwt-decode';
+import Cookies from 'js-cookie';
+import { AlertDialog, AlertContext, ApiContext } from 'utils';
+import { isTokenResponse, refresh, authApi, refreshableApi } from 'api';
 
 const ApiProvider = ({ children }: { children: ReactNode }) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const { alert } = useContext(AlertContext);
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -23,30 +23,77 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
     refreshSubscribers.push(callback);
   };
 
+  const isTokenValid = (token: string) => {
+    if (!token) return false;
+
+    interface TokenPayload {
+      exp: number;
+      iat: number;
+    }
+
+    const decoded = jwtDecode<TokenPayload>(token);
+    const currentTime = Date.now() / 1000;
+
+    return decoded.exp > currentTime;
+  };
+
+  const checkTokenWithAlert = async (token?: string) => {
+    if (!token) {
+      handleSessionExpired('utils.auth.loginRequired');
+    } else if (!isTokenValid(token)) {
+      handleSessionExpired('utils.auth.sessionExpired');
+    }
+  };
+
+  const handleSessionExpired = (messageKey: string) => {
+    alert(t(messageKey)).then(() => {
+      setSessionExpired(true);
+    });
+  };
+
+  const checkTokenFromCookieWithAlert = async () => {
+    const token = Cookies.get('access_token');
+    await checkTokenWithAlert(token);
+  };
+
+  useEffect(() => {
+    if (sessionExpired) {
+      navigate('/login');
+    }
+  }, [sessionExpired]);
+
   refreshableApi.interceptors.request.use((config) => {
     const accessToken = Cookies.get('access_token');
+    checkTokenWithAlert(accessToken);
+
     if (accessToken) {
       config.headers['Authorization'] = `Bearer ${accessToken}`;
     }
     return config;
   });
 
-  refreshableApi.interceptors.response.use(undefined, async (error) => {
-    const errorStatus = error.response.status;
-    const originalRequest = error.config;
-    const refresh_token = Cookies.get('refresh_token');
+  refreshableApi.interceptors.response.use(
+    (res) => {
+      setSessionExpired(false);
+      return res;
+    },
+    async (error) => {
+      const errorStatus = error.response.status;
+      const originalRequest = error.config;
+      const refresh_token = Cookies.get('refresh_token');
 
-    const isAccessTokenExpired = (status: number) => status === 401;
-    const isRefreshTokenExpired = (status: number) => status === 403;
+      const isAccessTokenExpired = (status: number) => status === 401;
+      const isRefreshTokenExpired = (status: number) => status === 403;
 
-    if (isAccessTokenExpired(errorStatus) && refresh_token) {
-      return handleAccessTokenExpiration(originalRequest, refresh_token);
-    } else if (isRefreshTokenExpired(errorStatus)) {
-      alert(t('utils.auth.sessionExpired')).then(() => navigate('login'));
-    } else {
-      return Promise.reject(error);
+      if (isAccessTokenExpired(errorStatus) && refresh_token) {
+        return handleAccessTokenExpiration(originalRequest, refresh_token);
+      } else if (isRefreshTokenExpired(errorStatus)) {
+        handleSessionExpired('utils.auth.sessionExpired');
+      } else {
+        return Promise.reject(error);
+      }
     }
-  });
+  );
 
   const handleAccessTokenExpiration = async (
     originalRequest: any,
@@ -75,7 +122,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
         throw new Error('Invalid token response');
       }
     } catch (error) {
-      alert(t('utils.auth.sessionExpired')).then(() => navigate('login'));
+      handleSessionExpired('utils.auth.sessionExpired');
       return Promise.reject(error);
     } finally {
       setIsRefreshing(false);
@@ -83,7 +130,9 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <ApiContext.Provider value={{ authApi, refreshableApi }}>
+    <ApiContext.Provider
+      value={{ authApi, refreshableApi, checkTokenFromCookieWithAlert }}
+    >
       {children}
       <AlertDialog />
     </ApiContext.Provider>

--- a/src/utils/provider/ApiProvider.tsx
+++ b/src/utils/provider/ApiProvider.tsx
@@ -119,13 +119,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
 
   refreshableApi.interceptors.request.use(async (config) => {
     const accessToken = await getAccessToken();
-
-    if (accessToken) {
-      config.headers['Authorization'] = `Bearer ${accessToken}`;
-    } else {
-      alertSessionExpiredThenRedirect();
-    }
-
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
     return config;
   });
 

--- a/src/utils/provider/ApiProvider.tsx
+++ b/src/utils/provider/ApiProvider.tsx
@@ -64,20 +64,20 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
     if (accessToken && isTokenValid(accessToken)) {
       return accessToken;
     } else {
-      return getAccessTokenByRefreshOrAlert();
+      return getNewAccessToken();
     }
   };
 
-  const getAccessTokenByRefreshOrAlert = async () => {
+  const getNewAccessToken = async () => {
     const refreshToken = Cookies.get('refresh_token');
     if (refreshToken) {
-      return tryGetAccessTokenByRefreshOrAlert(refreshToken);
+      return getAccessTokenByRefresh(refreshToken);
     } else {
       alertLoginRequired();
     }
   };
 
-  const tryGetAccessTokenByRefreshOrAlert = async (refreshToken: string) => {
+  const getAccessTokenByRefresh = async (refreshToken: string) => {
     if (isRefreshing) {
       return new Promise((resolve) => {
         addRefreshSubscriber((newToken) => resolve(newToken));
@@ -139,7 +139,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
       const originalRequest = error.config;
 
       if (isAccessTokenExpired(errorStatus, errorCode)) {
-        const newAccessToken = await getAccessTokenByRefreshOrAlert();
+        const newAccessToken = await getNewAccessToken();
         if (newAccessToken) {
           originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
           return refreshableApi(originalRequest);

--- a/src/utils/provider/ApiProvider.tsx
+++ b/src/utils/provider/ApiProvider.tsx
@@ -43,13 +43,13 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
     return decoded.exp > currentTime;
   };
 
-  const alertLoginRequired = () => {
+  const alertLoginRequiredThenRedirect = () => {
     alert(t('loginRequired')).then(() => {
       setRedirectLogin(true);
     });
   };
 
-  const alertSessionExpired = () => {
+  const alertSessionExpiredThenRedirect = () => {
     alert(t('sessionExpired')).then(() => {
       setRedirectLogin(true);
     });
@@ -73,7 +73,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
     if (refreshToken) {
       return getAccessTokenByRefresh(refreshToken);
     } else {
-      alertLoginRequired();
+      alertLoginRequiredThenRedirect();
     }
   };
 
@@ -102,7 +102,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
         const errorCode = errorResponse?.data?.code;
 
         if (isRefreshTokenExpired(errorStatus, errorCode)) {
-          alertSessionExpired();
+          alertSessionExpiredThenRedirect();
         }
       }
     } finally {
@@ -123,7 +123,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
     if (accessToken) {
       config.headers['Authorization'] = `Bearer ${accessToken}`;
     } else {
-      alertSessionExpired();
+      alertSessionExpiredThenRedirect();
     }
 
     return config;
@@ -141,7 +141,7 @@ const ApiProvider = ({ children }: { children: ReactNode }) => {
         return refreshableApi(originalRequest);
       }
     } else if (isRefreshTokenExpired(errorStatus, errorCode)) {
-      alertSessionExpired();
+      alertSessionExpiredThenRedirect();
     } else {
       await alert('utils.auth.serverError');
       return Promise.reject(error);


### PR DESCRIPTION
# 🔥 연관 이슈
- close #NULL-381

# 🚀 작업 내용
1. refresh 오류 수정
2. redirect 오류 수정

### ApiProvider 주요 메소드 정리
- checkTokenFromCookie : 액세스 토큰이 유효한지 확인하고, refresh 시도하는 메소드
- getAccessToken : 액세스 토큰이 있는지 확인하고 리턴하는 메소드
- getNewAccessToken : 새로운 액세스 토큰을 리턴하는 메소드
- getAccessTokenByRefresh : 새로운 액세스 토큰을 직접 요청(refresh)하고는 코드

# 스크린샷 (선택)

# 💬 리뷰 중점사항
