### PR TITLE
[NULL-285 NULL-429] Feature/ optimistic

### DIFF
--- a/src/api/refreshableApi/memoApi.ts
+++ b/src/api/refreshableApi/memoApi.ts
@@ -119,18 +119,18 @@ interface getMemosResponse extends validResponse {
   memos: Memo[];
 }
 
-export const getAllMemos = async (): Promise<
-  getMemosResponse | errorResponse
-> => {
+export const getAllMemos = async (
+  page: number
+): Promise<getMemosResponse | errorResponse> => {
   const method = getMethodName();
-  const endpoint = `/memos`;
+  const endpoint = `/tag/memos?page=${page}&sortOrder=LATEST`;
 
   try {
     const response = await refreshableApi.get(endpoint);
     const responseInfo = {
       method,
       status: response.status,
-      memos: response.data,
+      memos: response.data.memos,
     } as getMemosResponse;
     return responseInfo;
   } catch (error) {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -77,12 +77,8 @@
     "create": {
       "header": "메모 추가하기",
       "inputPlaceholder": "메모 작성...",
-      "createMemoMessage": "AI로 생성한 메모를 추가했습니다.",
+      "tagRebuilding": "태그 생성중...",
       "placeholder": "AI로 관련 태그를 자동으로 생성해드립니다.",
-      "memoCreateButton": {
-        "loading": "로딩 중...",
-        "default": "메모 생성하기"
-      },
       "errorMessage": "죄송합니다. 메모 추가 중에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.",
       "refreshButton": "새로고침(임시버튼)"
     },

--- a/src/pages/home/subPages/components/memo/MemoText/MemoText.tsx
+++ b/src/pages/home/subPages/components/memo/MemoText/MemoText.tsx
@@ -18,7 +18,7 @@ const MemoText = ({
 
   return (
     <TextareaAutosize
-      className="w-full bg-transparent focus:outline-none resize-none text-[#111111] font-regular text-[11px]"
+      className="w-full bg-transparent focus:outline-none resize-none text-[#111111] font-regular text-[15px]"
       value={message}
       onChange={handleChange}
       onBlur={handleBlur}

--- a/src/pages/home/subPages/components/memo/TagManager/TagCreateInput/TagCreateInput.tsx
+++ b/src/pages/home/subPages/components/memo/TagManager/TagCreateInput/TagCreateInput.tsx
@@ -30,7 +30,7 @@ const TagCreateInput = ({
 
   return (
     <div
-      className="flex flex-1 text-left focus:outline-none break-words self-center focus:self-center cursor:empty:before text-lg"
+      className="flex flex-auto text-left focus:outline-none break-words self-center focus:self-center cursor:empty:before text-[10px] self"
       ref={ref}
       contentEditable
       suppressContentEditableWarning

--- a/src/pages/home/subPages/components/memo/TagManager/TagManager.tsx
+++ b/src/pages/home/subPages/components/memo/TagManager/TagManager.tsx
@@ -6,7 +6,7 @@ import { Tag } from 'pages/home/subPages/interfaces';
 
 interface TagManagerProps {
   tags: Tag[];
-  editable: boolean;
+  editable?: boolean;
   setTags: (tags: Tag[]) => void;
 }
 const TagManager = ({ tags, editable, setTags }: TagManagerProps) => {
@@ -36,7 +36,7 @@ const TagManager = ({ tags, editable, setTags }: TagManagerProps) => {
   };
 
   return (
-    <div className="flex flex-wrap gap-1">
+    <div className="flex flex-wrap gap-1 flex-row items-center">
       {tags.map((tag, index) => (
         <EditableTag
           key={index}

--- a/src/pages/home/subPages/components/ui/EditableTag/EditableTag.tsx
+++ b/src/pages/home/subPages/components/ui/EditableTag/EditableTag.tsx
@@ -49,7 +49,7 @@ interface EditableTagProps {
 }
 
 const tagStyles = tv({
-  base: 'inline-flex flex-shrink-0 self-start items-center h-[1.25rem] py-[0.0625rem] px-[0.5625rem] gap-[5px]',
+  base: 'inline-flex shrink-0 self-center items-center h-[1.25rem] py-[0.0625rem] px-[0.5625rem] gap-[5px]',
   variants: {
     color: {
       white: 'bg-white',
@@ -123,7 +123,6 @@ const EditableTag = ({
         border: border,
         shadow: shadow,
       })} ${className}`}
-      style={{ position: 'relative', zIndex: 10 }}
       onClick={onClick}
     >
       <span

--- a/src/pages/home/subPages/interfaces/MemoSearch/MemoSearch.tsx
+++ b/src/pages/home/subPages/interfaces/MemoSearch/MemoSearch.tsx
@@ -23,5 +23,5 @@ export interface MemoSearchConversation {
   /**
    * 메모 검색 질문에 대한 대답
    */
-  answer: MemoSearchAnswer;
+  answer: MemoSearchAnswer | null;
 }

--- a/src/pages/home/subPages/main/Main.tsx
+++ b/src/pages/home/subPages/main/Main.tsx
@@ -1,15 +1,23 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Component from './components';
-import { Mode } from './interfaces';
-import { useCreateSearchMemoManager } from './hook';
+import { Mode, Status } from './interfaces';
+import { useCreateMemoManager, useSearchMemoManager } from './hooks';
 import { MemoSearchTextArea } from '../components/memo/MemoSearchTextArea';
 
 const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
   const { t } = useTranslation();
   const [message, setMessage] = useState('');
   const [mode, setMode] = useState<Mode>('create');
-  const createSearchNoteManager = useCreateSearchMemoManager(mode);
+  const [status, setStatus] = useState<Status>('default');
+  const createMemoManager = useCreateMemoManager({
+    status,
+    setStatus,
+  });
+  const searchMemoManager = useSearchMemoManager({
+    status,
+    setStatus,
+  });
 
   const isCreateMode = () => mode === 'create';
   const isSearchMode = () => mode === 'search';
@@ -27,9 +35,9 @@ const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
 
   const handleSubmit = (message: string) => {
     if (isCreateMode()) {
-      createSearchNoteManager.tryCreateMemoAndSetStatus(message, setMessage);
+      createMemoManager.tryCreateMemoAndSetStatus(message, setMessage);
     } else {
-      createSearchNoteManager.trySearchMemoAndSetStatus(message, setMessage);
+      searchMemoManager.trySearchMemoAndSetStatus(message, setMessage);
     }
   };
 
@@ -40,6 +48,10 @@ const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
   const handleCameraButtonClick = () => {
     // TODO: camera OCR 기능이 추가되면 코드 작성하기
   };
+
+  useEffect(() => {
+    setStatus('default'); // mode가 변경될 때마다 status를 초기화
+  }, [mode]);
 
   const buttonData: [string, string, string, string] = [
     '라면 레시피 메모 보여줘',
@@ -59,7 +71,7 @@ const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
         onCameraButtonClick={handleCameraButtonClick}
       />
       <Component.CreatedMemoList
-        memos={createSearchNoteManager.useMemoStack().data || []}
+        memos={createMemoManager.useMemoStack().data || []}
       />
     </>
   );
@@ -73,8 +85,8 @@ const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
         onSubmit={() => handleSubmit(message)}
       />
       <Component.ExamplesOrResultsAtSearchMode
-        status={createSearchNoteManager.status}
-        searchAnswer={createSearchNoteManager.searchAnswer}
+        status={status}
+        searchAnswer={searchMemoManager.searchAnswer}
         navigateToHistory={navigateToHistory}
         buttonData={buttonData}
         handleButtonClick={handleSubmit}

--- a/src/pages/home/subPages/main/Main.tsx
+++ b/src/pages/home/subPages/main/Main.tsx
@@ -86,7 +86,7 @@ const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
       />
       <Component.ExamplesOrResultsAtSearchMode
         status={status}
-        searchAnswer={searchMemoManager.searchAnswer}
+        searchConversation={searchMemoManager.searchConversation}
         navigateToHistory={navigateToHistory}
         buttonData={buttonData}
         handleButtonClick={handleSubmit}

--- a/src/pages/home/subPages/main/Main.tsx
+++ b/src/pages/home/subPages/main/Main.tsx
@@ -2,14 +2,14 @@ import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Component from './components';
 import { Mode } from './interfaces';
-import { useCreateSearchNoteManager } from './hook';
+import { useCreateSearchMemoManager } from './hook';
 import { MemoSearchTextArea } from '../components/memo/MemoSearchTextArea';
 
 const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
   const { t } = useTranslation();
   const [message, setMessage] = useState('');
   const [mode, setMode] = useState<Mode>('create');
-  const createSearchNoteManager = useCreateSearchNoteManager(mode);
+  const createSearchNoteManager = useCreateSearchMemoManager(mode);
 
   const isCreateMode = () => mode === 'create';
   const isSearchMode = () => mode === 'search';

--- a/src/pages/home/subPages/main/Main.tsx
+++ b/src/pages/home/subPages/main/Main.tsx
@@ -59,11 +59,7 @@ const MainPage = ({ navigateToHistory }: { navigateToHistory: () => void }) => {
         onCameraButtonClick={handleCameraButtonClick}
       />
       <Component.CreatedMemoList
-        memos={
-          createSearchNoteManager.createAnswer
-            ? [createSearchNoteManager.createAnswer]
-            : []
-        }
+        memos={createSearchNoteManager.useMemoStack().data || []}
       />
     </>
   );

--- a/src/pages/home/subPages/main/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
+++ b/src/pages/home/subPages/main/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
@@ -1,27 +1,23 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { deleteMemo, isValidResponse } from 'api';
 import { MemoText, TagManager } from 'pages/home/subPages/components';
 import { Memo } from 'pages/home/subPages/interfaces';
-import { BookIcon, DeleteIcon } from 'assets/icons';
+import { DeleteIcon } from 'assets/icons';
 import { format } from 'date-fns';
-import CircularProgress from '@mui/material/CircularProgress'; // MUI 로딩 컴포넌트 추가
 
 const CreatedMemoCardHeader = ({
-  aiName,
   updatedAt,
   handleDeleteMemo,
+  children,
 }: {
-  aiName: string;
   updatedAt: string;
   handleDeleteMemo: () => void;
+  children: ReactNode;
 }) => {
   return (
     <div className="flex">
-      <div className="flex gap-2 items-center mr-auto">
-        <BookIcon />
-        <p className="text-[#6A5344] font-extrabold select-none">{aiName}</p>
-      </div>
+      <div className="flex gap-2 items-center mr-auto">{children}</div>
       <div className="flex gap-2 items-center">
         <p className="text-[#6A5344] select-none">{updatedAt}</p>
         <button className="rounded-full">
@@ -64,25 +60,14 @@ const CreatedMemoCard = ({
       className="flex items-start px-7 py-[1.88rem] bg-[#FFF6E3CC] border border-black border-opacity-10 bg-clip-padding rounded-xl 
       shadow-custom backdrop-blur-lg"
     >
-      <div className="flex flex-col w-full gap-5">
+      <div className="flex flex-col w-full gap-9">
         <CreatedMemoCardHeader
-          aiName={t('pages.search.ai.name')}
           updatedAt={formatDate(new Date(memo.updated_at))}
           handleDeleteMemo={handleDeleteMemo}
-        />
-        <div className="flex flex-col gap-9">
-          {tags.length === 0 ? (
-            <div className="flex gap-3 text-sm">
-              <CircularProgress className="self-center" size={15} />
-              <p className="text-gray3 font-regular text-[11px]">
-                {t('pages.create.tagRebuilding')}
-              </p>
-            </div>
-          ) : (
-            <TagManager tags={tags} setTags={setTags} />
-          )}
-          <MemoText message={message} setMessage={setMessage} />
-        </div>
+        >
+          {tags.length !== 0 && <TagManager tags={tags} setTags={setTags} />}
+        </CreatedMemoCardHeader>
+        <MemoText message={message} setMessage={setMessage} />
       </div>
     </div>
   );

--- a/src/pages/home/subPages/main/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
+++ b/src/pages/home/subPages/main/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
@@ -5,6 +5,7 @@ import { MemoText, TagManager } from 'pages/home/subPages/components';
 import { Memo } from 'pages/home/subPages/interfaces';
 import { DeleteIcon } from 'assets/icons';
 import { format } from 'date-fns';
+import { Skeleton } from '@mui/material';
 
 const CreatedMemoCardHeader = ({
   updatedAt,
@@ -65,7 +66,11 @@ const CreatedMemoCard = ({
           updatedAt={formatDate(new Date(memo.updated_at))}
           handleDeleteMemo={handleDeleteMemo}
         >
-          {tags.length !== 0 && <TagManager tags={tags} setTags={setTags} />}
+          {tags.length === 0 ? (
+            <Skeleton animation="wave" width={50} />
+          ) : (
+            <TagManager tags={tags} setTags={setTags} />
+          )}
         </CreatedMemoCardHeader>
         <MemoText message={message} setMessage={setMessage} />
       </div>

--- a/src/pages/home/subPages/main/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
+++ b/src/pages/home/subPages/main/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
@@ -5,6 +5,7 @@ import { MemoText, TagManager } from 'pages/home/subPages/components';
 import { Memo } from 'pages/home/subPages/interfaces';
 import { BookIcon, DeleteIcon } from 'assets/icons';
 import { format } from 'date-fns';
+import CircularProgress from '@mui/material/CircularProgress'; // MUI 로딩 컴포넌트 추가
 
 const CreatedMemoCardHeader = ({
   aiName,
@@ -13,7 +14,7 @@ const CreatedMemoCardHeader = ({
 }: {
   aiName: string;
   updatedAt: string;
-  handleDeleteMemo: () => {};
+  handleDeleteMemo: () => void;
 }) => {
   return (
     <div className="flex">
@@ -70,7 +71,16 @@ const CreatedMemoCard = ({
           handleDeleteMemo={handleDeleteMemo}
         />
         <div className="flex flex-col gap-9">
-          <TagManager tags={tags} setTags={setTags} editable />
+          {tags.length === 0 ? (
+            <div className="flex gap-3 text-sm">
+              <CircularProgress className="self-center" size={15} />
+              <p className="text-gray3 font-regular text-[11px]">
+                {t('pages.create.tagRebuilding')}
+              </p>
+            </div>
+          ) : (
+            <TagManager tags={tags} setTags={setTags} />
+          )}
           <MemoText message={message} setMessage={setMessage} />
         </div>
       </div>

--- a/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ExamplesOrResultsAtSearchMode.tsx
+++ b/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ExamplesOrResultsAtSearchMode.tsx
@@ -5,7 +5,7 @@ import { Status } from 'pages/home/subPages/main/interfaces';
 
 interface ExamplesOrResultsAtSearchModeProps {
   status: Status;
-  searchAnswer?: Interface.MemoSearchConversation;
+  searchConversation?: Interface.MemoSearchConversation;
   navigateToHistory: () => void;
   buttonData: [string, string, string, string];
   handleButtonClick: (message: string) => void;
@@ -13,7 +13,7 @@ interface ExamplesOrResultsAtSearchModeProps {
 
 const ExamplesOrResultsAtSearchMode = ({
   status,
-  searchAnswer,
+  searchConversation,
   navigateToHistory,
   buttonData,
   handleButtonClick,
@@ -27,7 +27,7 @@ const ExamplesOrResultsAtSearchMode = ({
         />
       ) : (
         <ResultContent
-          searchAnswer={searchAnswer}
+          searchConversation={searchConversation}
           navigateToHistory={navigateToHistory}
         />
       )}

--- a/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ExamplesOrResultsAtSearchMode.tsx
+++ b/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ExamplesOrResultsAtSearchMode.tsx
@@ -25,13 +25,11 @@ const ExamplesOrResultsAtSearchMode = ({
           buttonData={buttonData}
           handleButtonClick={handleButtonClick}
         />
-      ) : status === 'success' ? (
+      ) : (
         <ResultContent
           searchAnswer={searchAnswer}
           navigateToHistory={navigateToHistory}
         />
-      ) : (
-        <></>
       )}
     </div>
   );

--- a/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ResultContent/ResultContent.tsx
+++ b/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ResultContent/ResultContent.tsx
@@ -4,16 +4,16 @@ import { MemoSearchConversation } from 'pages/home/subPages/interfaces';
 import { SearchConversation } from './SearchConversation';
 
 interface ResultContentProps {
-  searchAnswer?: MemoSearchConversation;
+  searchConversation?: MemoSearchConversation;
   navigateToHistory: () => void;
 }
 
 const ResultContent = ({
-  searchAnswer,
+  searchConversation,
   navigateToHistory,
 }: ResultContentProps) => {
   const { t } = useTranslation();
-  if (!searchAnswer) return;
+  if (!searchConversation) return;
 
   return (
     <>
@@ -22,8 +22,8 @@ const ResultContent = ({
           border-black border-opacity-10 bg-clip-padding bg-[#FFF6E3CC] font-regular"
       >
         <SearchConversation
-          key={searchAnswer.id}
-          data={searchAnswer}
+          key={searchConversation.id}
+          data={searchConversation}
           chatBotName={t('pages.search.ai.name')}
         />
       </div>

--- a/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ResultContent/SearchConversation/SearchConversation.tsx
+++ b/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ResultContent/SearchConversation/SearchConversation.tsx
@@ -1,3 +1,4 @@
+import { CircularProgress } from '@mui/material';
 import { BookIcon } from 'assets/icons';
 import { MemosList, UneditableMemo } from 'pages/home/subPages/components';
 import {
@@ -45,25 +46,36 @@ const UserQuestion = ({ contentText }: { contentText: string }) => {
   );
 };
 
-const AIAnswer = ({ content }: { content: MemoSearchAnswer }) => {
+const AIAnswer = ({ content }: { content: MemoSearchAnswer | null }) => {
   return (
     <div className="mt-[18px]">
-      <div className="inline bg-transparent resize-none whitespace-pre-wrap break-words">
-        {content.text}
-      </div>
-      <div className="flex flex-col w-full">
-        {content.memos && (
-          <div className="mt-[6px] text-center max-h-60 overflow-y-auto no-scrollbar">
-            <MemosList>
-              {content.memos?.map((memo) => (
-                <div key={memo.id} className="inline rounded-lg min-w-72">
-                  <UneditableMemo memo={memo} />
-                </div>
-              ))}
-            </MemosList>
+      {content ? (
+        <>
+          <div className="inline bg-transparent resize-none whitespace-pre-wrap break-words">
+            {content.text}
           </div>
-        )}
-      </div>
+          <div className="flex flex-col w-full">
+            {content.memos && (
+              <div className="mt-[6px] text-center max-h-60 overflow-y-auto no-scrollbar">
+                <MemosList>
+                  {content.memos?.map((memo) => (
+                    <div key={memo.id} className="inline rounded-lg min-w-72">
+                      <UneditableMemo memo={memo} />
+                    </div>
+                  ))}
+                </MemosList>
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="flex gap-3 text-sm">
+          <CircularProgress className="self-center" size={15} />
+          <p className="text-gray3 font-regular text-[11px]">
+            답변을 생성중입니다.
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ResultContent/SearchConversation/SearchConversation.tsx
+++ b/src/pages/home/subPages/main/components/ExamplesOrResultsAtSearchMode/ResultContent/SearchConversation/SearchConversation.tsx
@@ -15,7 +15,7 @@ const SearchConversation = ({
 }) => {
   return (
     <div key={data.id} className="px-6 h-full">
-      <div className="flex items-end">
+      <div className="flex items-start gap-4">
         <AIInfo name={chatBotName} />
         <UserQuestion contentText={data.query} />
       </div>
@@ -26,7 +26,7 @@ const SearchConversation = ({
 
 const AIInfo = ({ name }: { name: string }) => {
   return (
-    <div className="flex items-center">
+    <div className="flex flex-shrink-0 items-center">
       <BookIcon />
       <p className="ml-2 text-lg font-semibold">{name}</p>
     </div>

--- a/src/pages/home/subPages/main/components/ModeToggle/ModeToggle.tsx
+++ b/src/pages/home/subPages/main/components/ModeToggle/ModeToggle.tsx
@@ -11,7 +11,7 @@ const ModeToggle = ({ mode, onModeChange }: ModeToggleProps) => {
   const { t } = useTranslation();
 
   return (
-    <div className="flex gap-2 mx-5">
+    <div className="flex gap-2 mx-4">
       <ModeButton
         selected={mode === 'create'}
         icon={<AddIcon className="ml-1 mr-2" />}
@@ -44,8 +44,9 @@ const ModeButton = ({
   <button
     type="button"
     onClick={onModeChange}
-    className={` py-1 px-4 rounded-full inline-flex items-center border-[1px] font-bold border-black border-opacity-10 bg-clip-padding cursor-pointer 
-          ${selected ? 'bg-[#FFF6E3] text-[#6A5344]' : 'bg-[#F4CDB1] text-[#846E62]'} `}
+    className={`py-1 px-4 rounded-full inline-flex items-center border font-bold 
+      border-black border-opacity-10 bg-clip-padding cursor-pointer 
+      ${selected ? 'bg-[#FFF6E3] text-[#6A5344]' : 'bg-[#F4CDB1] text-[#846E62]'} `}
   >
     {icon}
     {text}

--- a/src/pages/home/subPages/main/hook/index.ts
+++ b/src/pages/home/subPages/main/hook/index.ts
@@ -1,1 +1,1 @@
-export { default as useCreateSearchNoteManager } from './useCreateSearchNoteManager';
+export { default as useCreateSearchMemoManager } from './useCreateSearchMemoManager';

--- a/src/pages/home/subPages/main/hook/index.ts
+++ b/src/pages/home/subPages/main/hook/index.ts
@@ -1,1 +1,0 @@
-export { default as useCreateSearchMemoManager } from './useCreateSearchMemoManager';

--- a/src/pages/home/subPages/main/hook/useCreateSearchMemoManager.ts
+++ b/src/pages/home/subPages/main/hook/useCreateSearchMemoManager.ts
@@ -8,7 +8,7 @@ import * as Interface from 'pages/home/subPages/interfaces';
 
 const MAX_SEARCH_QUERIES = 100;
 
-const useCreateSearchNoteManager = (mode: Mode) => {
+const useCreateSearchMemoManager = (mode: Mode) => {
   const [searchAnswer, setSearchAnswer] =
     useState<Interface.MemoSearchConversation>();
   const [status, setStatus] = useState<Status>('default');
@@ -189,4 +189,4 @@ const useCreateSearchNoteManager = (mode: Mode) => {
   };
 };
 
-export default useCreateSearchNoteManager;
+export default useCreateSearchMemoManager;

--- a/src/pages/home/subPages/main/hooks/index.ts
+++ b/src/pages/home/subPages/main/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useCreateMemoManager } from './useCreateMemoManager';
+export { default as useSearchMemoManager } from './useSearchMemoManager';

--- a/src/pages/home/subPages/main/hooks/useSearchMemoManager.ts
+++ b/src/pages/home/subPages/main/hooks/useSearchMemoManager.ts
@@ -1,0 +1,143 @@
+import { useState } from 'react';
+import { v4 as uuid_v4 } from 'uuid';
+import { Status } from '../interfaces';
+import * as Api from 'api';
+import * as Interface from 'pages/home/subPages/interfaces';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+const MAX_SEARCH_QUERIES = 100;
+
+const useSearchMemoManager = ({
+  status,
+  setStatus,
+}: {
+  status: Status;
+  setStatus: (status: Status) => void;
+}) => {
+  const queryClient = useQueryClient();
+  const [searchAnswer, setSearchAnswer] =
+    useState<Interface.MemoSearchConversation>();
+
+  const trySearchMemoAndSetStatus = async (
+    message: string,
+    setMessage: (message: string) => void
+  ) => {
+    if (message.trim()) {
+      setMessage('');
+      setStatus('loading');
+      try {
+        await mutateAsync(message);
+        setStatus('success');
+      } catch (error) {
+        setStatus('error');
+      }
+    }
+  };
+
+  const searchMemo = async (
+    query: string
+  ): Promise<Interface.MemoSearchAnswer> => {
+    const response = await Api.searchMemo(query);
+    if (!Api.isSearchMemoResponse(response)) {
+      throw new Error('Memo Create Error');
+    }
+    return response;
+  };
+
+  const { mutateAsync } = useMutation<
+    Interface.MemoSearchAnswer,
+    AxiosError,
+    string,
+    { conversationId: string; conversationQuery: string }
+  >({
+    mutationFn: searchMemo,
+    onMutate: async (query: string) => {
+      await queryClient.cancelQueries({
+        queryKey: ['searchHistory'],
+      });
+      const previousMemoSearchConversations =
+        queryClient.getQueryData<Interface.MemoSearchConversation[]>([
+          'searchHistory',
+        ]) || [];
+
+      const optimisticSearchConversation: Interface.MemoSearchConversation = {
+        id: uuid_v4(),
+        query: query,
+        answer: null,
+      };
+      setSearchAnswer(optimisticSearchConversation);
+
+      queryClient.setQueryData<Interface.MemoSearchConversation[]>(
+        ['searchHistory'],
+        [optimisticSearchConversation, ...previousMemoSearchConversations]
+      );
+
+      return {
+        conversationId: optimisticSearchConversation.id,
+        conversationQuery: optimisticSearchConversation.query,
+      };
+    },
+    onError: ({ context }: any) => {
+      const optimisticMemoId = context?.optimisticMemoId;
+      if (optimisticMemoId) {
+        queryClient.setQueryData<Interface.Memo[]>(
+          ['searchHistory'],
+          (oldMemos) =>
+            oldMemos?.filter((memo) => memo.id !== optimisticMemoId) || []
+        );
+      }
+    },
+    onSettled: (data, _, __, context) => {
+      const conversationId = context?.conversationId;
+      const conversationQuery = context?.conversationQuery;
+
+      if (data) {
+        const updatedSearchAnswer = {
+          id: conversationId,
+          query: conversationQuery,
+          answer: data,
+        } as Interface.MemoSearchConversation;
+
+        setSearchAnswer(updatedSearchAnswer);
+        // FIXME: searchHistory api연동되면 localhost에 저장하는 이 메소드 삭제.
+        saveSearchHistory(updatedSearchAnswer);
+
+        queryClient.setQueryData<Interface.MemoSearchConversation[]>(
+          ['searchHistory'],
+          (oldSearchHistories) =>
+            oldSearchHistories?.map((oldSearchHistory) =>
+              oldSearchHistory.id === conversationId
+                ? updatedSearchAnswer
+                : oldSearchHistory
+            ) || []
+        );
+      } else if (conversationId) {
+        queryClient.invalidateQueries({ queryKey: ['searchHistory'] });
+      }
+    },
+  });
+
+  const saveSearchHistory = (
+    newSearchAnswer: Interface.MemoSearchConversation
+  ) => {
+    const searchConversations = JSON.parse(
+      localStorage.getItem('search_queries') || '[]'
+    );
+    searchConversations.unshift(newSearchAnswer);
+
+    if (searchConversations.length > MAX_SEARCH_QUERIES) {
+      searchConversations.length = MAX_SEARCH_QUERIES;
+    }
+
+    localStorage.setItem('search_queries', JSON.stringify(searchConversations));
+  };
+
+  return {
+    status,
+    searchAnswer,
+    trySearchMemoAndSetStatus,
+  };
+};
+
+export default useSearchMemoManager;


### PR DESCRIPTION
# 🔥 연관 이슈
- close #NULL-285 #NULL-429

# 🚀 작업 내용
1. 메모 추가에 낙관적 업데이트 기능 추가
   - 미리 메모 추가는 해놓고, 태그가 생성되면, 그때 태그 표시
2. 메모 검색에 낙관적 업데이트 기능 추가
   - 검색 결과만 Progress 보이게 구현

# 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f3099836-5183-4001-8d79-11272d5dd83a)
![image](https://github.com/user-attachments/assets/7e253f19-426f-470d-8962-fb095541e7e9)
![image](https://github.com/user-attachments/assets/6be55d2b-b285-4eff-bfa0-652f69040085)
![image](https://github.com/user-attachments/assets/f39157bb-2436-4856-92bd-718f3adc2b90)

# 💬 리뷰 중점사항
일단 페이지네이션 api page 1페이지로 해서 낙관적 업데이트 부분만 테스트했는데, 
페이지네이션 브랜치에서 더 많은 메모로 직접 테스트 해볼께요. 여기서 작업하면 너무 코드양이 많아질 것 같아서. 

태그 생성하다 오류나면 어떻게 처리할까요? 
오류 나는 경우 지금 생각하기에는 refresh token 만료 -> 그냥 로그인 direct되게 설정
서버 오류 나는 경우 -> 그냥 메모 날라가는데, 어떻게 할지 모르겠네요. 
사용자를 생각한다면, 서버 오류의 경우 메모 내용 임시적으로 localStorage에 저장했다가 서버 다시 연결되면 다시 시도해야할 것 같은데 모르겠습니다. 