### PR TITLE
[NULL-612] feat: 요약 메모에 링크가 들어갈때, 링크가 전부 안 보이고 일부만 보이는 오류 수정하고, 링크를 눌렀을때, 해당 링크로…

### DIFF
--- a/src/pages/home/subPages/components/memo/SummaryMemo/MemoText/MemoText.tsx
+++ b/src/pages/home/subPages/components/memo/SummaryMemo/MemoText/MemoText.tsx
@@ -4,7 +4,7 @@ const MemoText = forwardRef<
   HTMLParagraphElement,
   { message: string; textColor?: string }
 >(({ message, textColor = '#111111' }, ref) => {
-  const paragraphRef = useRef<HTMLParagraphElement | null>(null);
+  const paragraphRef = useRef<HTMLDivElement | null>(null);
   const [isOverflowed, setIsOverflowed] = useState(false);
 
   useEffect(() => {
@@ -22,9 +22,17 @@ const MemoText = forwardRef<
     }
   }, [message]);
 
+  const convertToHyperlinks = (text: string) => {
+    const urlPattern = /(https?:\/\/[^\s]+)/g;
+    return text.replace(
+      urlPattern,
+      '<a id="memo-link" class="underline" href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
+    );
+  };
+
   return (
     <>
-      <p
+      <div
         ref={(node) => {
           paragraphRef.current = node;
           if (typeof ref === 'function') {
@@ -34,15 +42,20 @@ const MemoText = forwardRef<
           }
         }}
         className={`flex-col h-full bg-transparent focus:outline-none font-regular text-[15px] 
-          overflow-hidden text-ellipsis whitespace-break-spaces leading-5`}
+          overflow-hidden text-ellipsis whitespace-break-spaces break-all leading-5`}
         style={{
           color: textColor,
           display: '-webkit-box',
           WebkitBoxOrient: 'vertical',
         }}
-      >
-        {message}
-      </p>
+        onClick={(event) => {
+          const target = event.target as HTMLElement;
+          if (target.id === 'memo-link') {
+            event.stopPropagation();
+          }
+        }}
+        dangerouslySetInnerHTML={{ __html: convertToHyperlinks(message) }}
+      />
       {isOverflowed && <span style={{ color: textColor }}>...</span>}
     </>
   );


### PR DESCRIPTION
# 🔥 연관 이슈
- close #NULL-612

# 🚀 작업 내용
1. 요약 메모에서 링크가 전부 안 보이는 오류 수정
2. 링크를 눌렀을 때 해당 링크가 뜨게 수정
   - 이때, 메모 모달이 안뜨게 구현

# 스크린샷 (선택)
작업 전
![image](https://github.com/user-attachments/assets/54850f3a-5ff1-4ac3-95db-086cfcc0fff2)

작업 후
![image](https://github.com/user-attachments/assets/18ac18d3-f511-4a90-b06a-9cb7357c054a)

# 💬 리뷰 중점사항
