### PR TITLE
[NULL-625] Feature/null 625 metadata memo

### DIFF
--- a/src/pages/home/subPages/components/memo/EditableMemo/EditableMemo.tsx
+++ b/src/pages/home/subPages/components/memo/EditableMemo/EditableMemo.tsx
@@ -83,6 +83,7 @@ const EditableMemo = ({
             imageUrls={imageUrls}
             removeImageUrl={removeImageUrl}
             message={message}
+            metadata={memo.metadata}
             setMessage={setMessage}
             editable
           />

--- a/src/pages/home/subPages/components/memo/ImageMemoText/ImageMemoText.tsx
+++ b/src/pages/home/subPages/components/memo/ImageMemoText/ImageMemoText.tsx
@@ -8,12 +8,14 @@ const ImageMemoText = ({
   removeImageUrl,
   textColor,
   message,
+  metadata,
   setMessage,
   editable,
 }: {
   imageUrls: string[];
   removeImageUrl?: (index: number) => void;
   message: string;
+  metadata: string | null;
   textColor?: string;
   setMessage?: (newMessage: string) => void;
   editable?: boolean;
@@ -49,6 +51,7 @@ const ImageMemoText = ({
             <MemoText
               textColor={textColor}
               message={message}
+              metadata={metadata}
               setMessage={setMessage}
               editable={editable}
             />

--- a/src/pages/home/subPages/components/memo/ImageMemoText/MemoText/MemoText.tsx
+++ b/src/pages/home/subPages/components/memo/ImageMemoText/MemoText/MemoText.tsx
@@ -1,12 +1,15 @@
+import { Divider } from '@mui/material';
 import { FocusEvent, useRef, useState } from 'react';
 
 const MemoText = ({
   message,
+  metadata,
   textColor = '#111111',
   setMessage,
   editable = false,
 }: {
   message: string;
+  metadata: string | null;
   textColor?: string;
   setMessage?: (newMessage: string) => void;
   editable?: boolean;
@@ -21,6 +24,21 @@ const MemoText = ({
       '<a id="memo-link" class="underline cursor-pointer" href="$1" target="_blank">$1</a>'
     );
   };
+
+  const parsedMetadata = metadata ? JSON.parse(metadata) : null;
+
+  const voiceDescriptions = parsedMetadata?.voice_descriptions || null;
+  const linkDescriptions = parsedMetadata?.link_descriptions || null;
+  const imageDescriptions =
+    parsedMetadata?.image_descriptions?.[0]?.image_description || null;
+
+  const descriptions = voiceDescriptions
+    ? voiceDescriptions[0]
+    : linkDescriptions
+      ? linkDescriptions[0]
+      : imageDescriptions
+        ? imageDescriptions
+        : null;
 
   const handleBlur = (e: FocusEvent<HTMLDivElement>) => {
     if (!editable) return;
@@ -50,19 +68,29 @@ const MemoText = ({
   };
 
   return (
-    <div
-      ref={editableDivRef}
-      className={`w-full bg-transparent font-regular text-[15px] whitespace-break-spaces focus:outline-none
+    <>
+      <div
+        ref={editableDivRef}
+        className={`w-full bg-transparent font-regular text-[15px] whitespace-break-spaces focus:outline-none
         [&_a]:pointer-events-auto [&_a]:break-all select-text`}
-      style={{ color: textColor }}
-      contentEditable={editable}
-      onClick={handleClick}
-      suppressContentEditableWarning
-      onBlur={handleBlur}
-      dangerouslySetInnerHTML={{
-        __html: isBlurred ? convertToHyperlinks(message) : message,
-      }}
-    />
+        style={{ color: textColor }}
+        contentEditable={editable}
+        onClick={handleClick}
+        suppressContentEditableWarning
+        onBlur={handleBlur}
+        dangerouslySetInnerHTML={{
+          __html: isBlurred ? convertToHyperlinks(message) : message,
+        }}
+      />
+      {descriptions && (
+        <>
+          {(editable || message) && <Divider className="pt-2" />}
+          <p className={`${message ? 'pt-2' : ''} text-sm text-gray2`}>
+            {descriptions}
+          </p>
+        </>
+      )}
+    </>
   );
 };
 

--- a/src/pages/home/subPages/components/memo/SummaryMemo/MemoText/MemoText.tsx
+++ b/src/pages/home/subPages/components/memo/SummaryMemo/MemoText/MemoText.tsx
@@ -2,8 +2,8 @@ import { forwardRef, useEffect, useRef, useState } from 'react';
 
 const MemoText = forwardRef<
   HTMLParagraphElement,
-  { message: string; textColor?: string }
->(({ message, textColor = '#111111' }, ref) => {
+  { message: string; textColor?: string; lines?: number }
+>(({ message, textColor = '#111111', lines = 6 }, ref) => {
   const paragraphRef = useRef<HTMLDivElement | null>(null);
   const [isOverflowed, setIsOverflowed] = useState(false);
 
@@ -11,7 +11,7 @@ const MemoText = forwardRef<
     const element = paragraphRef.current;
     if (element) {
       const lineHeight = parseInt(window.getComputedStyle(element).lineHeight, 10);
-      const maxHeight = lineHeight * 6;
+      const maxHeight = lineHeight * lines;
       if (element.scrollHeight > maxHeight) {
         element.style.height = `${maxHeight}px`;
         element.style.overflow = 'hidden';

--- a/src/pages/home/subPages/components/memo/SummaryMemo/SummaryMemo.tsx
+++ b/src/pages/home/subPages/components/memo/SummaryMemo/SummaryMemo.tsx
@@ -6,6 +6,7 @@ import { MemoFooter } from './MemoFooter';
 import { ImageBlur } from './ImageBlur';
 import { MemoText } from './MemoText';
 import { TAG_INVALID_CHARS_PATTERN } from 'pages/home/constants';
+import { Divider } from '@mui/material';
 
 interface SummaryMemoProps extends HTMLProps<HTMLDivElement> {
   memo: Memo;
@@ -37,6 +38,21 @@ const SummaryMemo = ({
     imageUrl: string | undefined,
     defaultBackground: string
   ) => (haveImageUrl ? `url(${imageUrl})` : defaultBackground);
+
+  const parsedMetadata = memo.metadata ? JSON.parse(memo.metadata) : null;
+
+  const voiceDescriptions = parsedMetadata?.voice_descriptions || null;
+  const linkDescriptions = parsedMetadata?.link_descriptions || null;
+  const imageDescriptions =
+    parsedMetadata?.image_descriptions?.[0]?.image_description || null;
+
+  const descriptions = voiceDescriptions
+    ? voiceDescriptions[0]
+    : linkDescriptions
+      ? linkDescriptions[0]
+      : imageDescriptions
+        ? imageDescriptions
+        : null;
 
   return (
     <div
@@ -73,6 +89,16 @@ const SummaryMemo = ({
             textColor={getStyleByImagePresence('#111111', 'white')}
             message={memo.content}
           />
+        )}
+        {descriptions && (
+          <>
+            {memo.content && <Divider className="pt-2" />}
+            <MemoText
+              textColor={getStyleByImagePresence('gray2', 'white')}
+              lines={3}
+              message={descriptions}
+            />
+          </>
         )}
         <MemoFooter
           textColor={getStyleByImagePresence('gray2', 'white')}

--- a/src/pages/home/subPages/components/memo/SummaryMemo/SummaryMemo.tsx
+++ b/src/pages/home/subPages/components/memo/SummaryMemo/SummaryMemo.tsx
@@ -92,7 +92,9 @@ const SummaryMemo = ({
         )}
         {descriptions && (
           <>
-            {memo.content && <Divider className="pt-2" />}
+            {memo.content && (
+              <Divider sx={{ borderColor: '#eeeeee90' }} className="pt-2" />
+            )}
             <MemoText
               textColor={getStyleByImagePresence('gray2', 'white')}
               lines={3}

--- a/src/pages/home/subPages/create/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
+++ b/src/pages/home/subPages/create/components/CreatedMemoList/CreatedMemoCard/CreatedMemoCard.tsx
@@ -54,6 +54,7 @@ const CreatedMemoCard = ({ memo }: CreatedMemoCardProps) => {
         <ImageMemoText
           imageUrls={memo.image_urls}
           message={message}
+          metadata={memo.metadata}
           setMessage={setMessage}
         />
       </div>


### PR DESCRIPTION
# 🔥 연관 이슈
- close #NULL-625

# 🚀 작업 내용
1. 메모 추가 창의 메모에서 메타데이터 보이게 수정
2. 메모 수정 창에서 메타데이터 보이게 수정
3. 요약 메모에서 메타데이터 보이게 수정

- 메타데이터 보이는 순서
1. 음성 메타데이터
2. 링크 메타데이터
3. 이미지 메타데이터

# 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/0bcd068a-f7a0-430d-bd1d-149d7bdd90c1)
![image](https://github.com/user-attachments/assets/423ba750-1afe-4d16-bbbd-1382e02a9fe5)
![image](https://github.com/user-attachments/assets/98e51350-53b0-45a8-940d-be7fd2b8d333)
![image](https://github.com/user-attachments/assets/2ca8d0d0-880e-43e2-bf9b-6f7164359a61)

# 💬 리뷰 중점사항
